### PR TITLE
before subscribe esx host, need to unsubscribed the old pool

### DIFF
--- a/testcases/virt_who/esx/tc_ID155149_ESX_validate_complaince_after_starting_resuming.py
+++ b/testcases/virt_who/esx/tc_ID155149_ESX_validate_complaince_after_starting_resuming.py
@@ -23,10 +23,14 @@ class tc_ID155149_ESX_validate_complaince_after_starting_resuming(VIRTWHOBase):
             host_uuid = self.esx_get_host_uuid(destination_ip)
             self.esx_start_guest(guest_name)
             guestip = self.esx_get_guest_ip(guest_name, destination_ip)
+
             # register guest to SAM
             if not self.sub_isregistered(guestip):
                 self.configure_host(SAM_HOSTNAME, SAM_IP, guestip)
                 self.sub_register(SAM_USER, SAM_PASS, guestip)
+
+            # before subscribe esx host with limited subscription, need to clean all the old subscribed pool from SAM
+            self.esx_unsubscribe_all_host_in_samserv(host_uuid, SAM_IP)
             # subscribe esx host with limited bonus subscription
             self.esx_subscribe_host_in_samserv(host_uuid, self.get_poolid_by_SKU(test_sku) , SAM_IP)
             # subscribe the registered guest to the corresponding bonus pool

--- a/testcases/virt_who/virtwhobase.py
+++ b/testcases/virt_who/virtwhobase.py
@@ -230,6 +230,14 @@ class VIRTWHOBase(unittest.TestCase):
                 logger.info("Succeeded to unregister %s." % self.get_hg_info(targetmachine_ip))
             else:
                 raise FailException("Failed to unregister %s." % self.get_hg_info(targetmachine_ip))
+
+            # need to clean local data after unregister
+            cmd = "subscription-manager clean"
+            ret, output = self.runcmd(cmd, "clean system", targetmachine_ip)
+            if ret == 0 :
+                logger.info("Succeeded to clean %s." % self.get_hg_info(targetmachine_ip))
+            else:
+                raise FailException("Failed to clean %s." % self.get_hg_info(targetmachine_ip))
         else:
             logger.info("The machine is not registered to server now, no need to do unregister.")
 
@@ -437,8 +445,8 @@ class VIRTWHOBase(unittest.TestCase):
             raise FailException("Failed to list consumed subscriptions.")
 
     def sub_refresh(self, targetmachine_ip=""):
-        ''' refresh all local data. '''
-        cmd = "subscription-manager refresh; sleep 10"
+        ''' sleep 20 seconds firstly due to guest restart, and then refresh all local data. '''
+        cmd = "sleep 20; subscription-manager refresh"
         ret, output = self.runcmd(cmd, "subscription fresh", targetmachine_ip)
         if ret == 0 and "All local data refreshed" in output:
             logger.info("Succeeded to refresh all local data %s." % self.get_hg_info(targetmachine_ip))


### PR DESCRIPTION
before subscribe esx host, need to unsubscribed the old pool; 
after unregister, need to clean
if guest restart, need to sleep 20s, then refresh